### PR TITLE
Fix/for n dimension delaunay divide

### DIFF
--- a/DelaunayTables/Resources/C-Sources/DelaunayTable.IndexVector.c
+++ b/DelaunayTables/Resources/C-Sources/DelaunayTable.IndexVector.c
@@ -61,7 +61,7 @@ void IndexVector__sort(
     );
 }
 
-bool IndexVector__equality(
+bool IndexVector__equal(
     const IndexVector* const v0,
     const IndexVector* const v1
 ) {

--- a/DelaunayTables/Resources/C-Sources/DelaunayTable.IndexVector.h
+++ b/DelaunayTables/Resources/C-Sources/DelaunayTable.IndexVector.h
@@ -56,7 +56,7 @@ extern void IndexVector__sort(
     IndexVector* this
 );
 
-extern bool IndexVector__equality(
+extern bool IndexVector__equal(
     const IndexVector* v0,
     const IndexVector* v1
 );

--- a/DelaunayTables/Resources/C-Sources/DelaunayTable.Neighbor.c
+++ b/DelaunayTables/Resources/C-Sources/DelaunayTable.Neighbor.c
@@ -49,7 +49,7 @@ bool NeighborPairMap__get(
         face,
         (Object*) neighborPair,
         (Object__hash)  IndexVector__hash,
-        (Object__equal) IndexVector__equality
+        (Object__equal) IndexVector__equal
     );
 }
 
@@ -65,7 +65,7 @@ int NeighborPairMap__set(
         (Object__copy)   IndexVector__copy,
         (Object__delete) IndexVector__delete,
         (Object__hash)   IndexVector__hash,
-        (Object__equal)  IndexVector__equality,
+        (Object__equal)  IndexVector__equal,
         (Object__copy)   NeighborPair__copy,
         (Object__delete) NeighborPair__delete
     );
@@ -80,7 +80,7 @@ bool NeighborPairMap__remove(
         face,
         (Object__delete) IndexVector__delete,
         (Object__hash)   IndexVector__hash,
-        (Object__equal)  IndexVector__equality,
+        (Object__equal)  IndexVector__equal,
         (Object__delete) NeighborPair__delete
     );
 }

--- a/DelaunayTables/Resources/C-Sources/DelaunayTable.PolygonTree.c
+++ b/DelaunayTables/Resources/C-Sources/DelaunayTable.PolygonTree.c
@@ -1029,6 +1029,8 @@ void PolygonTreeVector__divide_at_point(
     const enum Verbosity verbosity,
     ResourceStack resources
 ) {
+    ResourceStack__enter(resources);
+
     int status = SUCCESS;
 
     FaceVector* faceVector = ResourceStack__ensure_delete_finally(
@@ -1134,4 +1136,6 @@ void PolygonTreeVector__divide_at_point(
             raise_Error(resources, "PolygonTreeVector__flip_face(...) failed");
         }
     }
+
+    ResourceStack__exit(resources);
 }

--- a/DelaunayTables/Resources/C-Sources/DelaunayTable.c
+++ b/DelaunayTables/Resources/C-Sources/DelaunayTable.c
@@ -212,15 +212,16 @@ static void DelaunayTable__extend_table(
         }
     }
 
+    const double big_coordinate = 2.0 * (double) nDim * maxAbs;
     // Assign extended table data
     for (size_t iPoint = 0 ; iPoint < nVerticesInPolygon(nDim) ; iPoint++) {
         double* const coords = (this->table_extended) + iPoint * nDim;
 
         for (size_t i = 0 ; i < nDim ; i++) {
             if (iPoint == 0) {
-                coords[i] = -4.0 * maxAbs;
+                coords[i] = -big_coordinate;
             } else if (iPoint == (i+1)) {
-                coords[i] = +4.0 * maxAbs;
+                coords[i] = +big_coordinate;
             } else {
                 coords[i] =  0.0;
             }


### PR DESCRIPTION
- fix big polygon (first virtual polygon) size for nD
- Add forgotten `Resourcestack__enter` `ResourceStack__end`  call
- Rename method `IndexVector__equality` => `IndexVector__equal`